### PR TITLE
feat : 이력서 생성 API

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import cookieParser from "cookie-parser";
 import { prisma } from "./src/utils/prisma.util.js";
 
 import UsersRouter from "./src/routes/users.router.js";
+import ResumesRouter from "./src/routes/resumes.router.js";
 import errorHandlerMiddleware from "./src/middlewares/error-handler.middleware.js";
 
 const app = express();
@@ -14,7 +15,7 @@ const PORT = 3018;
 app.use(express.json());
 app.use(cookieParser());
 
-app.use("/api", [UsersRouter]);
+app.use("/api", [UsersRouter, ResumesRouter]);
 app.use(errorHandlerMiddleware); // errorHandlerMiddleware는 마지막에 위치할 것!
 
 prisma.$connect();

--- a/src/middlewares/error-handler.middleware.js
+++ b/src/middlewares/error-handler.middleware.js
@@ -7,5 +7,8 @@ export default function (err, req, res, next) {
   // }
 
   // 클라이언트에게 에러 메시지를 전달합니다.
-  res.status(500).json({ errorMessage: "서버 내부 에러가 발생했습니다." });
+  res.status(500).json({
+    status: 500,
+    errorMessage: "서버 내부 에러가 발생했습니다.",
+  });
 }

--- a/src/routes/resumes.router.js
+++ b/src/routes/resumes.router.js
@@ -1,0 +1,56 @@
+import express from "express";
+import Joi from "joi";
+import { prisma } from "../utils/prisma.util.js";
+import errorHandlerMiddleware from "../middlewares/error-handler.middleware.js";
+import authorizationMiddleware from "../middlewares/authorization.middleware.js";
+
+const router = express.Router();
+
+/** 이력서 생성 API **/
+router.post("/resumes", authorizationMiddleware, async (req, res, next) => {
+  // 1. authorizationMiddleware 사용자 인증 => req.user 받기
+  // + 이력서 작성을 위한 resumeTitle, resumeContent를 req.body로 전달 받기
+  const { resumeTitle, resumeContent } = req.body;
+  // 2. resumeTitle, resumeContent가 모두 입력됐는지 확인
+  if (!resumeTitle) {
+    return res.status(400).json({
+      status: 400,
+      message: "이력서 제목을 입력하지 않았습니다. 다시 확인해주세요!",
+    });
+  }
+  if (!resumeContent) {
+    return res.status(400).json({
+      status: 400,
+      message: "이력서 내용을 입력하지 않았습니다. 다시 확인해주세요!",
+    });
+  }
+  // 3. resumeContent 가 150자 이상 적혔는지 확인
+  // 그렇지 않으면 - "자기소개는 150자 이상 작성해야합니다."
+  if (resumeContent.length < 150) {
+    return res.status(400).json({
+      status: 400,
+      message: "자기소개는 150자 이상 작성해야합니다.",
+    });
+  }
+  // 4. 작성자 userId는 인증 Middleware에서 전달받은 정보를 활용
+  const { userId } = req.user;
+  // 5. Resumes 테이블에 이력서 생성
+  // + resumeId, status(기본값APPLY), createdAt, updatedAt은 자동생성
+  // + status : APPLY, DROP, PASS, INTERVIEW1, INTERVIEW2, FINAL_PASS
+  const resume = await prisma.resumes.create({
+    data: {
+      UserId: +userId,
+      resumeTitle,
+      resumeContent,
+    },
+  });
+  // 0. 이력서 생성 결과를 클라이언트에 반환
+  // 반환 내용 : resumeId, userId, resumeTitle, resumeContent, status, createdAt, updatedAt
+  return res.status(201).json({
+    status: 201,
+    message: "이력서 생성이 완료되었습니다.",
+    data: resume,
+  });
+});
+
+export default router;

--- a/src/routes/users.router.js
+++ b/src/routes/users.router.js
@@ -3,6 +3,7 @@ import Joi from "joi";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { prisma } from "../utils/prisma.util.js";
+import errorHandlerMiddleware from "../middlewares/error-handler.middleware.js";
 import authorizationMiddleware from "../middlewares/authorization.middleware.js";
 
 const router = express.Router();
@@ -175,6 +176,13 @@ router.get("/users", authorizationMiddleware, async (req, res, next) => {
       updatedAt: true,
     },
   });
+  // 2-1. 데이터가 존재하지 않는 경우
+  if (!userInfo) {
+    return res.status(404).json({
+      status: 404,
+      message: "회원님의 정보가 존재하지 않습니다. 관리자에게 문의하세요.",
+    });
+  }
   // 3. 내 정보 조회 결과를 클라이언트에 반환 200
   return res.status(200).json({
     status: 200,


### PR DESCRIPTION
# 이력서 생성 API
새로운 이력서를 생성합니다.

## 요청 정보
- 사용자 정보는 인증 Middleware(req.user)를 통해서 전달 받음
- 제목, 자기소개를 Request Body(req.body)로 전달 받음

## 유효성 검증 및 에러 처리
- 제목, 자기소개 중 하나라도 빠진 경우 - "ㅇㅇ을 입력해주세요."
- 자기소개 글자 수가 150자보다 짧은 경우 - "자기소개는 150자 이상 작성해야합니다."
 
## 비즈니스 로직(데이터처리)
- 작성자 ID는 인증 Middleware에서 전달받은 정보를 활용
- 이력서 ID, 지원 상태, 생성일시, 수정일시는 자동 생성
- 지원 상태의 종류는 다음과 같으며, 기본 값은 APPLY
   - 서류 지원 완료 APPLY
   - 서류 탈락 DROP
   - 서류 합격 PASS
   - 1차 면접 INTERVIEW1
   - 2차 면접 INTERVIEW2
   - 최종 합격 FINAL_PASS
 
## 반환 정보
- 이력서 ID, 작성자 ID, 제목, 자기소개, 지원 상태, 생성일시, 수정일시 반환