### PR TITLE
feat : 이력서 목록 조회 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "joi": "^17.13.1",
     "jsonwebtoken": "^9.0.2",
     "prisma": "^5.14.0",
+    "query-string": "^9.0.0",
     "winston": "^3.13.0"
   },
   "devDependencies": {

--- a/src/routes/resumes.router.js
+++ b/src/routes/resumes.router.js
@@ -1,5 +1,6 @@
 import express from "express";
 import Joi from "joi";
+import queryString from "query-string";
 import { prisma } from "../utils/prisma.util.js";
 import errorHandlerMiddleware from "../middlewares/error-handler.middleware.js";
 import authorizationMiddleware from "../middlewares/authorization.middleware.js";
@@ -44,12 +45,80 @@ router.post("/resumes", authorizationMiddleware, async (req, res, next) => {
       resumeContent,
     },
   });
-  // 0. 이력서 생성 결과를 클라이언트에 반환
+  // 6. 이력서 생성 결과를 클라이언트에 반환
   // 반환 내용 : resumeId, userId, resumeTitle, resumeContent, status, createdAt, updatedAt
   return res.status(201).json({
     status: 201,
     message: "이력서 생성이 완료되었습니다.",
     data: resume,
+  });
+});
+
+/** 이력서 목록 조회 API **/
+router.get("/resumes", authorizationMiddleware, async (req, res, next) => {
+  // 1. authorizationMiddleware 사용자 인증 => req.user 받기
+  // + 쿼리스트링 사용을 위해 미리 정렬조건도 받기
+  const { userId } = req.user;
+  // const urlSearch = new URLSearchParams(window.location.search);
+  // const sortLike = urlSearch.get("sort").toString();
+  // let sortType = "desc";
+  // if (!sortLike) {
+  //   sortType = "desc";
+  // } else if (sortLike.toLowerCase() == "asc") {
+  //   sortType = "asc";
+  // } else {
+  //   sortType = "desc";
+  // } // 쿼리스트링 구현하려다가 실패했는데 시간이 없어서 일단 넘어감
+
+  // 2. 현재 로그인 한 사용자의 이력서 목록만 조회함(DB 조회시 작성자 ID가 일치해야)
+  // + 작성자 ID가 아닌 작성자 이름을 반환하기 위해 스키마에 정의한 Relation을 활용해 조회함
+  const resumes = await prisma.resumes.findMany({
+    select: {
+      resumeId: true,
+      User: {
+        // 스키마에 정의한 Relation을 활용해 조회
+        select: {
+          UserInfos: {
+            select: {
+              name: true, // 작성자id 대신 이름을 조회
+            },
+            where: {
+              UserId: +userId,
+            },
+          },
+        },
+      },
+      resumeTitle: true,
+      resumeContent: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: {
+      UserId: +userId,
+    },
+    orderBy: {
+      createdAt: "desc", // 일단 기본값은 최신순(desc)으로
+    },
+  });
+  // 추가구현 필요사항
+  // 0. Query Parameters(req.query)로 정렬 조건 받음 '?sort=asc'
+  // + 생성일시 기준 정렬은 과거순(ASC), 최신순(DESC)으로 전달 받음.
+  // + 대소문자 구분 없이 동작해야함
+  // + 정렬 조건에 따라 다른 결과값을 조회함
+  // 3. 조회결과가 없는 경우 - 빈 배열([ ])을 반환 (StatusCode: 200)
+  if (!resumes) {
+    return res.status(200).json({
+      status: 200,
+      message: "[ ]",
+    });
+  }
+  // 4. 이력서 목록 조회 결과를 클라이언트에 반환
+  // 반환 내용 : resumeId, name, resumeTitle, resumeContent, status, createdAt, updatedAt
+  return res.status(200).json({
+    status: 200,
+    message: "이력서 목록 조회가 완료되었습니다.",
+    data: resumes,
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,6 +359,11 @@ debug@4, debug@^4:
   dependencies:
     ms "2.1.2"
 
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
+
 define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
@@ -490,6 +495,11 @@ fill-range@^7.1.1:
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 finalhandler@1.2.0:
   version "1.2.0"
@@ -1035,6 +1045,15 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
+query-string@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-9.0.0.tgz#1fe177cd95545600f0deab93f5fb02fd4e3e7273"
+  integrity sha512-4EWwcRGsO2H+yzq6ddHcVqkCQ2EFUSfDMEjF8ryp8ReymyZhIuaFRGLomeOQLkrzacMHoyky2HW0Qe30UbzkKw==
+  dependencies:
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -1177,6 +1196,11 @@ simple-update-notifier@^2.0.0:
   integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
   dependencies:
     semver "^7.5.3"
+
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 stack-trace@0.0.x:
   version "0.0.10"


### PR DESCRIPTION
# 이력서 목록 조회 API (🔐AccessToken 인증 필요)
내가 등록한 이력서 목록을 조회합니다.

## 요청 정보
- 사용자 정보는 인증 Middleware(req.user)를 통해서 전달 받음
- Query Parameters(req.query)로 정렬 조건 받음 예) sort=desc
- 생성일시 기준 정렬은 과거순(ASC), 최신순(DESC)으로 전달 받음. 값이 없는 경우 최신순(DESC) 정렬을 기본으로 함. 대소문자 구분 없이 동작해야함.

## 유효성 검증 및 에러 처리
- 일치하는 값이 없는 경우 - 빈 배열([ ])을 반환 (StatusCode: 200)

## 비즈니스 로직(데이터 처리)
- 현재 로그인 한 사용자가 작성한 이력서 목록만 조회함
- DB에서 이력서 조회시 작성자 ID가 일치해야함
- 정렬 조건에 따라 다른 결과값을 조회함
- 작성자 ID가 아닌 작성자 이름을 반환하기 위해 스키마에 정의한 Relation을 활용해 조회함

## 반환 정보
- 이력서 ID, 작성자 이름, 제목, 자기소개, 지원 상태, 생성일시, 수정일시의 목록을 반환