### PR TITLE
feat : 이력서 상세 조회 API

### DIFF
--- a/src/routes/resumes.router.js
+++ b/src/routes/resumes.router.js
@@ -59,16 +59,7 @@ router.get("/resumes", authorizationMiddleware, async (req, res, next) => {
   // 1. authorizationMiddleware 사용자 인증 => req.user 받기
   // + 쿼리스트링 사용을 위해 미리 정렬조건도 받기
   const { userId } = req.user;
-  // const urlSearch = new URLSearchParams(window.location.search);
-  // const sortLike = urlSearch.get("sort").toString();
-  // let sortType = "desc";
-  // if (!sortLike) {
-  //   sortType = "desc";
-  // } else if (sortLike.toLowerCase() == "asc") {
-  //   sortType = "asc";
-  // } else {
-  //   sortType = "desc";
-  // } // 쿼리스트링 구현하려다가 실패했는데 시간이 없어서 일단 넘어감
+  const { sort } = req.query;
 
   // 2. 현재 로그인 한 사용자의 이력서 목록만 조회함(DB 조회시 작성자 ID가 일치해야)
   // + 작성자 ID가 아닌 작성자 이름을 반환하기 위해 스키마에 정의한 Relation을 활용해 조회함
@@ -98,14 +89,10 @@ router.get("/resumes", authorizationMiddleware, async (req, res, next) => {
       UserId: +userId,
     },
     orderBy: {
-      createdAt: "desc", // 일단 기본값은 최신순(desc)으로
+      createdAt: sort ? sort.toLowerCase() : "desc", // 기본값은 최신순(desc)
     },
   });
-  // 추가구현 필요사항
-  // 0. Query Parameters(req.query)로 정렬 조건 받음 '?sort=asc'
-  // + 생성일시 기준 정렬은 과거순(ASC), 최신순(DESC)으로 전달 받음.
-  // + 대소문자 구분 없이 동작해야함
-  // + 정렬 조건에 따라 다른 결과값을 조회함
+
   // 3. 조회결과가 없는 경우 - 빈 배열([ ])을 반환 (StatusCode: 200)
   if (!resumes) {
     return res.status(200).json({
@@ -121,5 +108,62 @@ router.get("/resumes", authorizationMiddleware, async (req, res, next) => {
     data: resumes,
   });
 });
+
+/** 이력서 상세 조회 API **/
+router.get(
+  "/resumes/:resumeId",
+  authorizationMiddleware,
+  async (req, res, next) => {
+    // 1. 사용자 정보는 인증 Middleware(req.user)를 통해 전달 받음
+    const { userId } = req.user;
+    // 2. 이력서 ID를 Path Parameters(req.params)로 전달 받음
+    const { resumeId } = req.params;
+    // 3. 현재 로그인 한 사용자가 작성한 이력서만 조회함
+    // + DB에서 이력서 조회 시 이력서 ID, 작성자 ID가 모두 일치해야 함
+    // + userId가 아닌 name 반환을 위해 스키마에 정의한 Relation을 활용
+    const resume = await prisma.resumes.findFirst({
+      select: {
+        resumeId: true,
+        User: {
+          // 스키마에 정의한 Relation을 활용해 조회
+          select: {
+            UserInfos: {
+              select: {
+                name: true, // 작성자id 대신 이름을 조회
+              },
+              where: {
+                UserId: +userId,
+              },
+            },
+          },
+        },
+        resumeTitle: true,
+        resumeContent: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      where: {
+        UserId: +userId,
+        resumeId: +resumeId,
+      },
+    });
+
+    // 4. 이력서 정보가 없는 경우 - "내가 쓴 이력서가 아니거나, 이력서가 존재하지 않습니다."
+    if (!resume) {
+      return res.status(404).json({
+        status: 404,
+        message: "내가 쓴 이력서가 아니거나, 이력서가 존재하지 않습니다.",
+      });
+    }
+    // 0. 이력서 상세 조회 결과를 클라이언트에 반환
+    // 내용 : resumeId, name, resumeTitle, resumeContent, status, createdAt, updatedAt
+    return res.status(200).json({
+      status: 200,
+      message: "이력서 상세 조회가 완료되었습니다.",
+      data: resume,
+    });
+  },
+);
 
 export default router;


### PR DESCRIPTION
# 이력서 상세 조회 API (🔐AccessToken 인증 필요)
내가 등록한 이력서의 상세 정보를 조회합니다.

## 요청 정보
- 사용자 정보는 인증 Middleware(req.user)를 통해 전달 받음
- 이력서 ID를 Path Parameters(req.params)로 전달 받음

## 유효성 검증 및 에러 처리
- 이력서 정보가 없는 경우 - "내가 쓴 이력서가 아니거나, 이력서가 존재하지 않습니다."

## 비즈니스 로직(데이터 처리)
- 현재 로그인 한 사용자가 작성한 이력서만 조회함
- DB에서 이력서 조회 시 이력서 ID, 작성자 ID가 모두 일치해야 함
- 작성자 ID가 아닌 작성자 이름을 반환하기 위해 스키마에 정의한 Relation을 활용해 조회함

## 반환 정보
- 이력서 ID, 작성자 이름, 제목, 자기소개, 지원 상태, 생성일시, 수정일시 반환